### PR TITLE
Merge with main

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -1,5 +1,6 @@
+---
 name: Mirror to NWBRaVE
-on:
+'on':
   push:
     branches: ["**"]
     tags: ["**"]
@@ -27,9 +28,32 @@ jobs:
       - name: Mirror branches and tags
         run: |
           set -euo pipefail
+
+          echo "Initializing bare repository for mirroring..."
           git init --bare repo.git
           cd repo.git
-          git remote add upstream https://github.com/EMSL-Computing/grip-tomo.git
-          git fetch --prune upstream '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
+
+          echo "Configuring git..."
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+          echo "Adding upstream remote..."
+          git remote add upstream \
+            https://github.com/EMSL-Computing/grip-tomo.git
+
+          echo "Fetching all refs from upstream..."
+          git fetch --prune upstream \
+            '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
+
+          echo "Adding destination remote..."
           git remote add dest git@github.com:NWBRaVE/grip-tomo.git
+
+          echo "Pushing mirror to destination..."
           git push --mirror dest
+
+          echo "Mirror completed successfully!"
+
+      - name: Cleanup SSH key
+        if: always()
+        run: |
+          rm -f ~/.ssh/id_ed25519

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -32,9 +32,7 @@ jobs:
       - name: Mirror branches and tags
         run: |
           set -euo pipefail
-          git init --bare repo.git
+          git clone --mirror https://github.com/EMSL-Computing/grip-tomo.git repo.git
           cd repo.git
-          git remote add upstream https://github.com/EMSL-Computing/grip-tomo.git
-          git fetch --prune upstream '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
           git remote add dest git@github.com:NWBRaVE/grip-tomo.git
           git push --mirror dest

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -1,0 +1,35 @@
+name: Mirror to NWBRaVE
+on:
+  push:
+    branches: ["**"]
+    tags: ["**"]
+  delete:
+  workflow_dispatch:
+
+concurrency:
+  group: mirror
+  cancel-in-progress: true
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH for pushing to NWBRaVE
+        env:
+          MIRROR_SSH_KEY: ${{ secrets.MIRROR_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          echo "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
+
+      - name: Mirror branches and tags
+        run: |
+          set -euo pipefail
+          git init --bare repo.git
+          cd repo.git
+          git remote add upstream https://github.com/EMSL-Computing/grip-tomo.git
+          git fetch --prune upstream '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
+          git remote add dest git@github.com:NWBRaVE/grip-tomo.git
+          git push --mirror dest

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -4,8 +4,8 @@ on:
     branches: ["**"]
     tags: ["**"]
   delete:
-    branches: ['**']
-    tags: ['**']
+    branches: ["**"]
+    tags: ["**"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -4,6 +4,8 @@ on:
     branches: ["**"]
     tags: ["**"]
   delete:
+    branches: ["**"]
+    tags: ["**"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -23,8 +23,7 @@ jobs:
           set -euo pipefail
           if [ -z "$MIRROR_SSH_KEY" ]; then echo "Error: MIRROR_SSH_KEY secret is not set"; exit 1; fi
           mkdir -p ~/.ssh
-          printf '%s\n' "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
+          (umask 077; printf '%s\n' "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519)
           # Add official GitHub SSH host keys to known_hosts (see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
           echo "|1|f8sELpAo0P5NdVs4KJIp4jOSAmI=|nX+ZspGDZCBoBPXaGNsq4CPGK/c= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE2fW4vFf8gDuwZQ+Q0jrISFRCGDpa2BkL4Z1p1g6U5R" >> ~/.ssh/known_hosts
           echo "|1|N2vCuxnxOQk4LLx7sMMEZe2qTfA=|kFGr2PzefDs2fzGEylh4G6dkcnQ= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4O0s8AjtKoaVHgMHqmpYyqn1bVbWcv16O3Qe9n3VWeItPxX2VINeodIZ6Tn6PvxI6Bfq5lHppZArYrusS4x+h0/pk3jfbQ3VIAtF+wNCz7L+G2kZZgwyU0vbzUKGwEuITdSb9VjA36TObgGJE0E7E5Wdl66iRS0LlwM651c01qmPvvrLpzjAU6RzGmmKzBSSo+d5QwDFi1Cdm42Hcps225y7sY9qsK0kGugHgdGXcwKYBJ38qJNmPR9U1FVLtZLkNVr7DiIP9N6byN1Nsx3Rp3XIan+FJxuxMxDPZWS9Vyuk3F7S3w7Dnk3a1JpN96CBvs1+FiSVqSdz+CA0nVddOQ==" >> ~/.ssh/known_hosts

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
-          echo "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
+          printf '%s\n' "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
 

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -4,13 +4,11 @@ on:
     branches: ["**"]
     tags: ["**"]
   delete:
-    branches: ["**"]
-    tags: ["**"]
   workflow_dispatch:
 
 concurrency:
   group: mirror
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   mirror:
@@ -24,10 +22,7 @@ jobs:
           if [ -z "$MIRROR_SSH_KEY" ]; then echo "Error: MIRROR_SSH_KEY secret is not set"; exit 1; fi
           mkdir -p ~/.ssh
           (umask 077; printf '%s\n' "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519)
-          # Add official GitHub SSH host keys to known_hosts (see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
-          echo "|1|f8sELpAo0P5NdVs4KJIp4jOSAmI=|nX+ZspGDZCBoBPXaGNsq4CPGK/c= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE2fW4vFf8gDuwZQ+Q0jrISFRCGDpa2BkL4Z1p1g6U5R" >> ~/.ssh/known_hosts
-          echo "|1|N2vCuxnxOQk4LLx7sMMEZe2qTfA=|kFGr2PzefDs2fzGEylh4G6dkcnQ= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4O0s8AjtKoaVHgMHqmpYyqn1bVbWcv16O3Qe9n3VWeItPxX2VINeodIZ6Tn6PvxI6Bfq5lHppZArYrusS4x+h0/pk3jfbQ3VIAtF+wNCz7L+G2kZZgwyU0vbzUKGwEuITdSb9VjA36TObgGJE0E7E5Wdl66iRS0LlwM651c01qmPvvrLpzjAU6RzGmmKzBSSo+d5QwDFi1Cdm42Hcps225y7sY9qsK0kGugHgdGXcwKYBJ38qJNmPR9U1FVLtZLkNVr7DiIP9N6byN1Nsx3Rp3XIan+FJxuxMxDPZWS9Vyuk3F7S3w7Dnk3a1JpN96CBvs1+FiSVqSdz+CA0nVddOQ==" >> ~/.ssh/known_hosts
-          echo "|1|l5vVsQt1zArhcXd1LSeX776BF3M=|sxuKOSeaMDAnbcW2CYwiVdc+GqY= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE7DhZZrVSu2Ce279b9Ec/WWEDuJeayQMZT6ZX0hgqP/d9vywgq6Z9erjRzCQXDpUe1koRaSPoaqe7iT730GgxY=" >> ~/.ssh/known_hosts
+          ssh-keyscan -t ed25519,ecdsa-sha2-nistp256,rsa github.com >> ~/.ssh/known_hosts
 
       - name: Mirror branches and tags
         run: |
@@ -35,5 +30,5 @@ jobs:
           git clone --mirror https://github.com/EMSL-Computing/grip-tomo.git repo.git
           cd repo.git
           git remote add dest git@github.com:NWBRaVE/grip-tomo.git
-          # Push all branches and tags, but exclude internal GitHub refs like refs/pull/*
+          # Push branches and tags, pruning deletions; exclude refs/pull/*
           git push dest 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' --prune --force

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: mirror
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   mirror:

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -20,8 +20,12 @@ jobs:
           MIRROR_SSH_KEY: ${{ secrets.MIRROR_SSH_KEY }}
         run: |
           set -euo pipefail
+          if [ -z "$MIRROR_SSH_KEY" ]; then
+            echo "Error: MIRROR_SSH_KEY secret is not set"
+            exit 1
+          fi
           mkdir -p ~/.ssh
-          echo "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
+          printf '%s\n' "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
 
@@ -49,7 +53,10 @@ jobs:
           git remote add dest git@github.com:NWBRaVE/grip-tomo.git
 
           echo "Pushing mirror to destination..."
-          git push --mirror dest
+          # Push all branches and tags, but exclude internal GitHub refs
+          # like refs/pull/* to avoid "deny updating a hidden ref" errors
+          git push dest 'refs/heads/*:refs/heads/*' \
+            'refs/tags/*:refs/tags/*' --prune
 
           echo "Mirror completed successfully!"
 

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -21,6 +21,7 @@ jobs:
           MIRROR_SSH_KEY: ${{ secrets.MIRROR_SSH_KEY }}
         run: |
           set -euo pipefail
+          if [ -z "$MIRROR_SSH_KEY" ]; then echo "Error: MIRROR_SSH_KEY secret is not set"; exit 1; fi
           mkdir -p ~/.ssh
           printf '%s\n' "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -36,4 +36,5 @@ jobs:
           git clone --mirror https://github.com/EMSL-Computing/grip-tomo.git repo.git
           cd repo.git
           git remote add dest git@github.com:NWBRaVE/grip-tomo.git
-          git push --mirror dest
+          # Push all branches and tags, but exclude internal GitHub refs like refs/pull/*
+          git push dest 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' --prune

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -22,7 +22,10 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
+          # Add official GitHub SSH host keys to known_hosts (see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
+          echo "|1|f8sELpAo0P5NdVs4KJIp4jOSAmI=|nX+ZspGDZCBoBPXaGNsq4CPGK/c= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE2fW4vFf8gDuwZQ+Q0jrISFRCGDpa2BkL4Z1p1g6U5R" >> ~/.ssh/known_hosts
+          echo "|1|N2vCuxnxOQk4LLx7sMMEZe2qTfA=|kFGr2PzefDs2fzGEylh4G6dkcnQ= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4O0s8AjtKoaVHgMHqmpYyqn1bVbWcv16O3Qe9n3VWeItPxX2VINeodIZ6Tn6PvxI6Bfq5lHppZArYrusS4x+h0/pk3jfbQ3VIAtF+wNCz7L+G2kZZgwyU0vbzUKGwEuITdSb9VjA36TObgGJE0E7E5Wdl66iRS0LlwM651c01qmPvvrLpzjAU6RzGmmKzBSSo+d5QwDFi1Cdm42Hcps225y7sY9qsK0kGugHgdGXcwKYBJ38qJNmPR9U1FVLtZLkNVr7DiIP9N6byN1Nsx3Rp3XIan+FJxuxMxDPZWS9Vyuk3F7S3w7Dnk3a1JpN96CBvs1+FiSVqSdz+CA0nVddOQ==" >> ~/.ssh/known_hosts
+          echo "|1|l5vVsQt1zArhcXd1LSeX776BF3M=|sxuKOSeaMDAnbcW2CYwiVdc+GqY= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE7DhZZrVSu2Ce279b9Ec/WWEDuJeayQMZT6ZX0hgqP/d9vywgq6Z9erjRzCQXDpUe1koRaSPoaqe7iT730GgxY=" >> ~/.ssh/known_hosts
 
       - name: Mirror branches and tags
         run: |

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -1,10 +1,11 @@
----
 name: Mirror to NWBRaVE
-'on':
+on:
   push:
     branches: ["**"]
     tags: ["**"]
   delete:
+    branches: ['**']
+    tags: ['**']
   workflow_dispatch:
 
 concurrency:
@@ -20,47 +21,20 @@ jobs:
           MIRROR_SSH_KEY: ${{ secrets.MIRROR_SSH_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "$MIRROR_SSH_KEY" ]; then
-            echo "Error: MIRROR_SSH_KEY secret is not set"
-            exit 1
-          fi
+          if [ -z "$MIRROR_SSH_KEY" ]; then echo "Error: MIRROR_SSH_KEY secret is not set"; exit 1; fi
           mkdir -p ~/.ssh
           printf '%s\n' "$MIRROR_SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
+          # Add official GitHub SSH host keys to known_hosts (see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
+          echo "|1|f8sELpAo0P5NdVs4KJIp4jOSAmI=|nX+ZspGDZCBoBPXaGNsq4CPGK/c= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE2fW4vFf8gDuwZQ+Q0jrISFRCGDpa2BkL4Z1p1g6U5R" >> ~/.ssh/known_hosts
+          echo "|1|N2vCuxnxOQk4LLx7sMMEZe2qTfA=|kFGr2PzefDs2fzGEylh4G6dkcnQ= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4O0s8AjtKoaVHgMHqmpYyqn1bVbWcv16O3Qe9n3VWeItPxX2VINeodIZ6Tn6PvxI6Bfq5lHppZArYrusS4x+h0/pk3jfbQ3VIAtF+wNCz7L+G2kZZgwyU0vbzUKGwEuITdSb9VjA36TObgGJE0E7E5Wdl66iRS0LlwM651c01qmPvvrLpzjAU6RzGmmKzBSSo+d5QwDFi1Cdm42Hcps225y7sY9qsK0kGugHgdGXcwKYBJ38qJNmPR9U1FVLtZLkNVr7DiIP9N6byN1Nsx3Rp3XIan+FJxuxMxDPZWS9Vyuk3F7S3w7Dnk3a1JpN96CBvs1+FiSVqSdz+CA0nVddOQ==" >> ~/.ssh/known_hosts
+          echo "|1|l5vVsQt1zArhcXd1LSeX776BF3M=|sxuKOSeaMDAnbcW2CYwiVdc+GqY= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE7DhZZrVSu2Ce279b9Ec/WWEDuJeayQMZT6ZX0hgqP/d9vywgq6Z9erjRzCQXDpUe1koRaSPoaqe7iT730GgxY=" >> ~/.ssh/known_hosts
 
       - name: Mirror branches and tags
         run: |
           set -euo pipefail
-
-          echo "Initializing bare repository for mirroring..."
-          git init --bare repo.git
+          git clone --mirror https://github.com/EMSL-Computing/grip-tomo.git repo.git
           cd repo.git
-
-          echo "Configuring git..."
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-
-          echo "Adding upstream remote..."
-          git remote add upstream \
-            https://github.com/EMSL-Computing/grip-tomo.git
-
-          echo "Fetching all refs from upstream..."
-          git fetch --prune upstream \
-            '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
-
-          echo "Adding destination remote..."
           git remote add dest git@github.com:NWBRaVE/grip-tomo.git
-
-          echo "Pushing mirror to destination..."
-          # Push all branches and tags, but exclude internal GitHub refs
-          # like refs/pull/* to avoid "deny updating a hidden ref" errors
-          git push dest 'refs/heads/*:refs/heads/*' \
-            'refs/tags/*:refs/tags/*' --prune
-
-          echo "Mirror completed successfully!"
-
-      - name: Cleanup SSH key
-        if: always()
-        run: |
-          rm -f ~/.ssh/id_ed25519
+          # Push all branches and tags, but exclude internal GitHub refs like refs/pull/*
+          git push dest 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' --prune

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -37,4 +37,4 @@ jobs:
           cd repo.git
           git remote add dest git@github.com:NWBRaVE/grip-tomo.git
           # Push all branches and tags, but exclude internal GitHub refs like refs/pull/*
-          git push dest 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' --prune
+          git push dest 'refs/heads/*:refs/heads/*' 'refs/tags/*:refs/tags/*' --prune --force

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -4,6 +4,8 @@ on:
     branches: ["**"]
     tags: ["**"]
   delete:
+    branches: ['**']
+    tags: ['**']
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically mirror branches and tags from the current repository to the `NWBRaVE/grip-tomo` repository. The workflow is triggered on any branch or tag creation, deletion, or manual dispatch, and uses SSH for secure authentication.

Automation and workflow setup:

* Added `.github/workflows/mirror.yaml` to automate mirroring of branches and tags to the `NWBRaVE/grip-tomo` repository, triggered on push, delete, and workflow dispatch events.
* Configured SSH authentication in the workflow using the `MIRROR_SSH_KEY` secret for secure access to the destination repository.
* Implemented concurrency control to ensure only one mirror job runs at a time, canceling any in-progress jobs.

Mirroring logic:

* The workflow clones the source repository as a mirror and pushes all branches and tags to the destination, pruning deletions and excluding pull request refs.